### PR TITLE
Lower log levels

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linebased"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Joe Wilm <joe@jwilm.com>"]
 license = "MIT OR Apache-2.0"
 description = "Add a TCP query port to any program"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,4 @@
-use std::io;
-use std::net;
+use std::{error, fmt, io, net};
 
 /// Error from linebased crate
 #[derive(Debug)]
@@ -9,29 +8,27 @@ pub enum Error {
 
     /// Error parsing listen address
     AddrParse(net::AddrParseError),
+
+    /// No bytes were read from the stream
+    NoBytesRead,
 }
 
-impl ::std::error::Error for Error {
-    fn cause(&self) -> Option<&dyn std::error::Error> {
+impl error::Error for Error {
+    fn source(&self) -> Option<&(dyn 'static + std::error::Error)> {
         match *self {
             Error::Io(ref err) => Some(err),
             Error::AddrParse(ref err) => Some(err),
-        }
-    }
-
-    fn description(&self) -> &str {
-        match *self {
-            Error::Io(ref err) => err.description(),
-            Error::AddrParse(ref err) => err.description(),
+            Error::NoBytesRead => None,
         }
     }
 }
 
-impl ::std::fmt::Display for Error {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Error::Io(ref err) => write!(f, "Linebased Server Error: {}", err),
-            Error::AddrParse(ref err) => write!(f, "Linebased Server Error: {}", err),
+            Error::AddrParse(ref err) => write!(f, "Error parsing address: {}", err),
+            Error::NoBytesRead => write!(f, "No bytes read from stream"),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,7 +234,7 @@ impl Client {
         response.push('\n');
 
         self.writer.write_all(response.as_bytes()).await?;
-        trace!("Wrote response: \"{}\"", response);
+        trace!("Wrote response: \"{}\"", response.trim());
 
         Ok(())
     }


### PR DESCRIPTION
It is not necessarily an error when the connection ends, so it should not be logged as such. This matches the old behavior of a connection being dropped in linebased 0.3 https://github.com/jwilm/linebased/blob/080ebc85e580a9d240d945d8d8f3159f59a31335/src/lib.rs#L144. I also added some trace logging that will allow you to verify the request/response logs per request if desired.

I can release 0.4.2 when this is merged.