### PR TITLE
Upgrade to tokio 1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 0.5.0
+
+- Upgrade to tokio 1.x

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linebased"
-version = "0.4.3"
+version = "0.5.0"
 authors = ["Joe Wilm <joe@jwilm.com>"]
 license = "MIT OR Apache-2.0"
 description = "Add a TCP query port to any program"
@@ -10,10 +10,10 @@ documentation = "http://blog.jwilm.io/linebased/linebased/index.html"
 edition = "2018"
 
 [dependencies]
-tokio = { version = "0.2", features = ["tcp", "sync", "rt-core", "io-util", "blocking"] }
+tokio = { version = "1", features = ["net", "sync", "rt", "io-util"] }
 log = "0.4"
 futures = "0.3"
 
 [dev-dependencies]
-tokio = { version = "0.2", features = ["macros", "rt-threaded"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@
 #![warn(missing_docs)]
 
 use std::io;
-use std::net::{Shutdown, SocketAddr};
+use std::net::SocketAddr;
 use std::str;
 use std::sync::Arc;
 
@@ -215,15 +215,16 @@ impl Client {
             }
         }
 
-        self.shutdown();
+        self.shutdown().await;
     }
 
-    fn shutdown(self) {
+    async fn shutdown(self) {
         if let Err(e) = self
             .reader
             .into_inner()
             .unsplit(self.writer)
-            .shutdown(Shutdown::Both)
+            .shutdown()
+            .await
         {
             debug!("Error closing socket connection {:?}", e);
         }
@@ -336,7 +337,7 @@ impl Server {
     /// Run the event loop
     pub async fn run(&mut self) -> io::Result<()> {
         info!("Listening at {}", self.address);
-        let mut listener = TcpListener::bind(self.address).await?;
+        let listener = TcpListener::bind(self.address).await?;
 
         loop {
             futures::select! {


### PR DESCRIPTION
Tokio 1 is required for compatibility with the rest of the up-to-date Rust
async ecosystem.